### PR TITLE
Add functionality to check if models are downloaded in the settings model

### DIFF
--- a/src/utils/model-data.ts
+++ b/src/utils/model-data.ts
@@ -10,6 +10,37 @@ const dbName = "whisperModels";
 const modelBaseUrl =
   "https://link.storjshare.io/s/jueavj4qtolpgszkbp5awref22da/models";
 
+export function getDownloadedModels(): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    if (!navigator.storage || !navigator.storage.estimate) {
+      console.log("loadRemote: navigator.storage.estimate() is not supported");
+    }
+
+    const openRequest = indexedDB.open(dbName, dbVersion);
+
+    openRequest.onsuccess = function () {
+      const db = openRequest.result;
+      const tx = db.transaction(["models"], "readonly");
+      const objectStore = tx.objectStore("models");
+      const localFilesRequest = objectStore.getAllKeys();
+
+      localFilesRequest.onsuccess = function () {
+        resolve((localFilesRequest.result as string[]) || []);
+      };
+
+      localFilesRequest.onerror = function () {
+        console.error("Failed to fetch models");
+        reject(new Error("Failed to fetch models"));
+      };
+    };
+
+    openRequest.onerror = function () {
+      console.error("Failed to open request to indexedDB");
+      reject(new Error("Failed to open request to indexedDB"));
+    };
+  });
+}
+
 // TODO: this method seems to leak memory when changing models
 export function loadOrGetModel(
   selectedModel: keyof typeof whisperModelSizes | "" | undefined,


### PR DESCRIPTION
This PR introduces functionality to determine whether a model is downloaded in the application. It includes `getDownloadedModels` function to fetch downloaded models from IndexedDB and enhancements to the component that displays models to indicate if they are downloaded.
![image](https://github.com/cmgriffing/orderly/assets/28809905/91aa6048-573b-40f5-8a95-fbd8f28bb8df)
